### PR TITLE
Removed peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,9 +19,6 @@
     "dependencies": {
         "debug": "*"
     },
-    "peerDependencies": {
-        "koa": "~0.3.0"
-    },
     "devDependencies": {
         "koa": "~0.3.0",
         "mocha": "~1.17.1",


### PR DESCRIPTION
This can allow the latest koa to use this middleware.
